### PR TITLE
Skip some tests when executed from a workflow

### DIFF
--- a/__tests__/integrationTests/youtube.test.ts
+++ b/__tests__/integrationTests/youtube.test.ts
@@ -1,3 +1,8 @@
+// Use CI environment variable to skip tests that will fail when blocked by the bot detection.
+const isCI = process.env.CI === 'true';
+// Conditionally skip the test if running in CI
+const conditionalTest = isCI ? test.skip : test;
+
 // We are differenciating between "standard navigation" (the user goes directly to the video url)
 // and "SPA navigation" (the user goes to the video after, for example, searching for it). This is
 // necessary because some information is not availabe to the bookmarklet in SPA navigation and it
@@ -54,12 +59,12 @@ const youtubeStandardTests = (name: string, url: string) => {
       expect(popupElement).not.toBeNull();
     });
 
-    it('should contain at least one download element', async () => {
+    conditionalTest('should contain at least one download element', async () => {
       const listItems = await page.$$('xpath/.//*[@id="dsc_popup"]/ul/li/a/p[2]');
       expect(listItems.length).toBeGreaterThan(0);
     });
 
-    it('should have an english subtitle', async () => {
+    conditionalTest('should have an english subtitle', async () => {
       const listItems = await page.$$('xpath/.//*[@id="dsc_popup"]/ul/li/a/p[2]');
       const titleItems = await Promise.all(listItems.map(async (item) => {
         const title = await page.evaluate((it) => it.textContent, item);
@@ -134,7 +139,7 @@ const youtubeSPATests = (name: string, searchUrl: string) => {
       expect(popupElement).not.toBeNull();
     });
 
-    it('should contain at least one download element', async () => {
+    conditionalTest('should contain at least one download element', async () => {
       const listElements = await page.$$('xpath/.//*[@id="dsc_popup"]/ul/li');
       expect(listElements.length).toBeGreaterThan(0);
     });

--- a/__tests__/integrationTests/youtube.test.ts
+++ b/__tests__/integrationTests/youtube.test.ts
@@ -13,6 +13,7 @@ const youtubeStandardTestInput = [{
 const youtubeStandardTests = (name: string, url: string) => {
   describe(name, () => {
     beforeAll(async () => {
+      await page.setBypassCSP(true);
       await page.goto(url, { waitUntil: 'networkidle0' });
 
       // Cookie consent
@@ -86,6 +87,7 @@ const youtubeSPATestInput = [{
 const youtubeSPATests = (name: string, searchUrl: string) => {
   describe(name, () => {
     beforeAll(async () => {
+      await page.setBypassCSP(true);
       await page.goto(searchUrl, { waitUntil: 'networkidle0' });
 
       // Cookie consent

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "rollup --config rollup.config.dev.mjs --watch",
     "build": "rollup --config rollup.config.prod.mjs",
     "test": "npm run test:unit && npm run test:integration",
+    "test:ci": "CI=true npm run test:unit && CI=true npm run test:integration",
     "test:unit": "jest __tests__/unitTests -c jest-unit.config.js --verbose",
     "test:integration": "server-test _runHttp-server http://localhost:8080 _runJestIntegration",
     "_runHttp-server": "node ./utils/tests_server.js",


### PR DESCRIPTION
These tests fail because of the bot detection implemented by the web (a workflow is always detected as a bot).

Unfortunately, we cannot fix this. Our solution is to skip these tests when executed from a workflow and leave the full list of tests for development.