### PR TITLE
Fix vods from ongoing livestreams

### DIFF
--- a/__tests__/integrationTests/twitch.test.ts
+++ b/__tests__/integrationTests/twitch.test.ts
@@ -1,20 +1,11 @@
 import { prepareEmptyDir, checkFileExistsWithTimeout } from '../testUtils/fileUtils';
 
 const path = require('path');
-
 const fs = require('fs');
-
-const twitchTestInput = [
-  {
-    name: 'Bob Ross Anniversary video',
-    url: 'https://www.twitch.tv/videos/100285305',
-    expectedFileName: '100285305.m3u8',
-  },
-];
 
 const downloadsPath = path.join(__dirname, '../tmp_downloads');
 
-const twitchTests = (name: string, url: string, expectedFileName: string) => {
+const twitchLiveTests = (name: string, url: string, expectedFileName: string) => {
   describe(name, () => {
     beforeAll(async () => {
       // @ts-ignore Set download destination
@@ -39,26 +30,80 @@ const twitchTests = (name: string, url: string, expectedFileName: string) => {
       await checkFileExistsWithTimeout(filePath, 6000);
     }, 10000);
 
+    it('should have downloaded a file"', () => {
+      // This is just a PoC for future tests
+      const files = fs.readdirSync(downloadsPath);
+      expect(files.length).toBeGreaterThan(0);
+    });
+
     afterAll(() => {
       // Delete downloads directory recursively
       if (fs.existsSync(downloadsPath)) {
         fs.rmSync(downloadsPath, { recursive: true, force: true });
       }
     });
-
-    it('should have downloaded a file"', () => {
-      // This is just a PoC for future tests
-      const files = fs.readdirSync(downloadsPath);
-      expect(files.length).toBeGreaterThan(0);
-    });
   });
 };
 
-describe('Twitch', () => {
-  twitchTestInput.forEach((it) => {
-    twitchTests(it.name, it.url, it.expectedFileName);
+const twitchVodTests = (name: string, url: string) => {
+  describe(name, () => {
+    beforeAll(async () => {
+      // Open page
+      await page.goto(url);
+      // Inject bookmarklet
+      await page.addScriptTag({ url: 'http://localhost:8080/dist/main.js' });
+    }, 10000);
+
+    it('should show the popup window', async () => {
+      const popupElement = await page.waitForSelector('xpath/.//*[@id="dsc_popup"]', { visible: true, timeout: 5000 });
+      expect(popupElement).not.toBeNull();
+    });
+
+    it('should contain at least one download element', async () => {
+      // Step 1: Wait until the first popup list element is added
+      await page.waitForSelector('xpath/.//*[@id="dsc_popup"]/ul/li', { visible: true, timeout: 5000 });
+      // Step 2: Check if there is more than one
+      // NOTE: Since our popup elements are added one by one, this check should always return 1 and is not really neccessary. 
+      //  We are leaving it as a reference in case we decide to modify how the popup gets populated and we want to test it.
+      const listItemCount = await page.$$eval('xpath/.//*[@id="dsc_popup"]/ul/li', items => items.length);
+      expect(listItemCount).toBeGreaterThan(0);
+    });
+
+    // TODO: Check if we can download m3u8 files by clicking an element from the popup
+  });
+};
+
+describe('Twitch live', () => {
+  [
+    {
+      // This is the channel with the highest viewer count in the "Always On" category
+      // https://www.twitch.tv/directory/category/always-on?sort=VIEWER_COUNT
+      name: 'Always live channel',
+      url: 'https://www.twitch.tv/theburntpeanut_247',
+      expectedFileName: 'theburntpeanut_247.m3u8',
+    }
+  ].forEach((it) => {
+    twitchLiveTests(it.name, it.url, it.expectedFileName);
   });
 });
+
+describe('Twitch VOD', () => {
+  [
+    {
+      // Old vods use different format segment.
+      // See twitch.js for more info.
+      name: 'Bob Ross Anniversary video (legacy formats)',
+      url: 'https://www.twitch.tv/videos/100285305',
+    },
+    {
+      name: 'Bob Ross Anniversary video (modern formats)',
+      url: 'https://www.twitch.tv/videos/2374922078',
+    },
+  ].forEach((it) => {
+    twitchVodTests(it.name, it.url);
+  });
+});
+
 
 // Run just this file
 // npx jest __tests__/integrationTests/twitch.test.ts -c jest-integration.config.js

--- a/src-bookmarklet/popup/popup.css
+++ b/src-bookmarklet/popup/popup.css
@@ -6,12 +6,13 @@
   width: 360px;
   right: 16px;
   bottom: 16px;
-  z-index: 2202;
+  z-index: 3000;
   border-radius: 2px;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
   animation: animateElement linear 0.3s;
   transition: opacity 0.3s ease-out;
 }
+
 #dsc_popup.card * {
   font-size: 100%;
   margin: 0;
@@ -89,6 +90,7 @@
     opacity: 0;
     transform: translate(0px, 10px);
   }
+
   100% {
     opacity: 1;
     transform: translate(0px, 0px);

--- a/src-bookmarklet/twitch/twitch.ts
+++ b/src-bookmarklet/twitch/twitch.ts
@@ -1,4 +1,4 @@
-import { getLiveAccessToken, getVideoAccessToken } from './utils/accessUtils';
+import { getLiveAccessToken, getBaseDvrUrl } from './utils/accessUtils';
 
 interface CommonOptions {
   headers: Record<string, string>;
@@ -72,14 +72,101 @@ function getVodId() {
 }
 
 /**
- * Get the manifest (m3u8 file) of a live channel
+ * Check URL against known formats and select the one with the best quality
+ * @param baseUrl 
+ * @returns A Promise with the best m3u8 url or undefined if we where unable to find one.
  */
-async function getManigestVideoUrl(videoId: string, clientId: string) {
-  const accessToken = await getVideoAccessToken(clientId, videoId);
-  // Form url
-  const { signature } = accessToken;
-  const encodedToken = encodeURIComponent(accessToken.token);
-  return `https://usher.ttvnw.net/vod/${videoId}.m3u8?sig=${signature}&token=${encodedToken}`;
+async function getBestM3u8FromSupportedFormats(baseUrl: string): Promise<string | undefined> {
+
+  // NOTE: For "Source" quality it will normally use "chunked" instead of a format string. 
+  //  Since we are not checking against "chunked", we will probably always get the second-best quality.
+  // TODO: We could display a quality selector
+  const formats = [
+    "1080p60",  // HighHighFPS
+    "1080p30",  // High
+    "720p60",   // MediumHighFPS
+    "720p30",   // Medium
+    "360p30",   // Low
+    "160p30"    // VeryLow
+  ]
+
+  // Check all known formats and stop when we find one that exists.
+  for (const format of formats) {
+    const formatUrl = `${baseUrl}/${format}/index-dvr.m3u8`
+    // We use a full fetch instead of just HEAD because it creates CORS issues.
+    const response = await fetch(formatUrl);
+    if (response.ok) {
+      return formatUrl
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Default dvr m3u8 files use relative paths for its .ts files. We need to transform it
+ * to use full paths before it can be downloaded.
+ * @param url The m3u8 file url.
+ * @returns A Promise with the tranformend m3u8 content as a string.
+ */
+async function transformRelativeM3u8ToFullPath(url: string): Promise<string> {
+
+  // Remove last piece from the url to get the base url that will be added to the .ts entries
+  const baseUrl = url.replace(/\/[^/]*$/, '/');
+
+  // Fetch the m3u8 content
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error("Unable to fetch manifest")
+  }
+  const m3u8Content = await response.text()
+
+  // For each line, replace relative .ts entries with full path URLs
+  const m3u8Pieces = m3u8Content
+    .split('\n')
+    .map(line => {
+      // Match lines that look like a segment file, e.g., "23.ts"
+      if (/^\d+\.ts$/.test(line.trim())) {
+        return baseUrl.replace(/\/$/, '') + '/' + line.trim();
+      }
+      return line;
+    })
+
+  // Make sure our m3u8 file ends with #EXT-X-ENDLIST
+  // If we are working with a VOD from an ongoing livestream, this line won't exist.
+  // To ensure the generated m3u8 plays/downloads from the beginning, check if 
+  // the line exists and add it if it doesn't.
+  let lastNonEmptyIndex: number | undefined = undefined;
+  for (let i = m3u8Pieces.length - 1; i >= 0; i--) {
+    if (m3u8Pieces[i] !== "") {
+      lastNonEmptyIndex = i;
+      break;
+    }
+  }
+
+  if (lastNonEmptyIndex && m3u8Pieces[lastNonEmptyIndex] !== "#EXT-X-ENDLIST") {
+    m3u8Pieces.splice(lastNonEmptyIndex + 1, 0, "#EXT-X-ENDLIST")
+  }
+
+  return m3u8Pieces.join('\n')
+
+}
+
+/**
+ * Download some string content as a m3u8 file
+ * @param filename The name of the new file.
+ * @param content The content of the new file.
+ */
+function downloadM3u8File(filename: string, content: string) {
+  const blob = new Blob([content], { type: "application/vnd.apple.mpegurl" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
 async function main(): Promise<void> {
@@ -94,8 +181,14 @@ async function main(): Promise<void> {
     const vodId = getVodId();
     if (vodId) {
       const clientId = getClientId();
-      const videoManifestUrl = await getManigestVideoUrl(vodId, clientId);
-      window.location.href = videoManifestUrl;
+      const baseDvrUrl = await getBaseDvrUrl(clientId, vodId)
+      const bestAvailableM3u8 = await getBestM3u8FromSupportedFormats(baseDvrUrl)
+      if (bestAvailableM3u8) {
+        const m3u8Content = await transformRelativeM3u8ToFullPath(bestAvailableM3u8)
+        downloadM3u8File(`${vodId}.m3u8`, m3u8Content)
+      } else {
+        console.warn("Unable to find a valid format")
+      }
     }
   }
 }

--- a/src-bookmarklet/twitch/twitch.ts
+++ b/src-bookmarklet/twitch/twitch.ts
@@ -7,6 +7,22 @@ interface CommonOptions {
 }
 declare const commonOptions: CommonOptions;
 
+interface SupportedFormat {
+  name: string;
+  urlSegment: string;
+}
+
+const supportedFormats: SupportedFormat[] = [
+  { name: "Source", urlSegment: "chunked", },
+  { name: "1080p60", urlSegment: "1080p60", },
+  { name: "1080p30", urlSegment: "1080p30", },
+  { name: "720p60", urlSegment: "720p60", },
+  { name: "720p30", urlSegment: "720p30", },
+  { name: "480p30", urlSegment: "480p30", },
+  { name: "360p30", urlSegment: "360p30", },
+  { name: "160p30", urlSegment: "160p30", },
+]
+
 /**
  * Get assigned client id
  */
@@ -78,25 +94,11 @@ function getVodId() {
  * @param baseUrl 
  * @returns A Promise with the list of available formats.
  */
-async function getAllM3u8FromSupportedFormats(baseUrl: string): Promise<{ format: string, url: string }[]> {
-
-  // NOTE: For "Source" quality it will normally use "chunked" instead of a format string. 
-  //  Since we are not checking against "chunked", we will probably always get the second-best quality.
-  // TODO: We could display a quality selector
-  const formats = [
-    "chunked",  // Source?
-    "1080p60",  // HighHighFPS
-    "1080p30",  // High
-    "720p60",   // MediumHighFPS
-    "720p30",   // Medium
-    "480p30",
-    "360p30",   // Low
-    "160p30"    // VeryLow
-  ]
+async function getAllM3u8FromSupportedFormats(baseUrl: string): Promise<{ format: SupportedFormat, url: string }[]> {
 
   // Create Promises to check all known formats
-  const promises = formats.map(async format => {
-    const formatUrl = `${baseUrl}/${format}/index-dvr.m3u8`
+  const promises = supportedFormats.map(async format => {
+    const formatUrl = `${baseUrl}/${format.urlSegment}/index-dvr.m3u8`
     // NOTE: We use a full fetch instead of just HEAD to avoid CORS issues.
     const response = await fetch(formatUrl);
     return {
@@ -210,8 +212,8 @@ async function main(): Promise<void> {
         // Add each available m3u8 to the popup
         availableM3u8.forEach((item) => {
           popup.addItemToList({
-            title: item.format,
-            subtitle: item.format,
+            title: item.format.name,
+            subtitle: item.format.urlSegment,
             url: item.url
           });
         })

--- a/src-bookmarklet/twitch/twitch.ts
+++ b/src-bookmarklet/twitch/twitch.ts
@@ -199,7 +199,7 @@ async function main(): Promise<void> {
       const popup = new Popup(async (receivedData) => {
         // Start download when an item from the popup is clicked
         const m3u8Content = await transformRelativeM3u8ToFullPath(receivedData.url)
-        downloadM3u8File(`${vodId}.m3u8`, m3u8Content)
+        downloadM3u8File(`${vodId}_${receivedData.subtitle}.m3u8`, m3u8Content)
       });
 
       // Display our empty popup instead of waiting for the results

--- a/src-bookmarklet/twitch/utils/accessUtils.ts
+++ b/src-bookmarklet/twitch/utils/accessUtils.ts
@@ -23,7 +23,7 @@ interface AccessToken {
  * @param channelName If the petition is for a live channel, this has to be the channel name.
  * @param videoId If the petition is for a VOD, this has to be the id of the video.
  */
-async function getAccessTokenResponse(clientId: string, isLive: boolean, channelName = '', videoId = '') : Promise<ApiResponse> {
+async function getAccessTokenResponse(clientId: string, isLive: boolean, channelName = '', videoId = ''): Promise<ApiResponse> {
   const gqlTemplate = `
     query PlaybackAccessToken_Template($login: String!, $isLive: Boolean!, $vodID: ID!, $isVod: Boolean!, $playerType: String!) {
       streamPlaybackAccessToken(channelName: $login, params: {platform: "web", playerBackend: "mediaplayer", playerType: $playerType}) @include(if: $isLive) {
@@ -68,7 +68,7 @@ async function getAccessTokenResponse(clientId: string, isLive: boolean, channel
 export async function getLiveAccessToken(
   clientId: string,
   channelName: string,
-) : Promise<AccessToken> {
+): Promise<AccessToken> {
   const dataJson = await getAccessTokenResponse(clientId, true, channelName, undefined);
   const { value: token, signature } = dataJson.data.streamPlaybackAccessToken;
   return { token, signature };
@@ -77,8 +77,76 @@ export async function getLiveAccessToken(
 export async function getVideoAccessToken(
   clientId: string,
   videoId: string,
-) : Promise<AccessToken> {
+): Promise<AccessToken> {
   const dataJson = await getAccessTokenResponse(clientId, false, undefined, videoId);
   const { value: token, signature } = dataJson.data.videoPlaybackAccessToken;
   return { token, signature };
+}
+
+/**
+ * Get the shared structure for the different index-dvr.m3u8 URLs. This can be used to generate valid index-dvr.m3u8 URLs.
+
+ * @param videoId The id of the video
+ * @returns A string with the part of the URL that is shared between dvr m3u8 files.
+ */
+export async function getBaseDvrUrl(clientId: string, videoId: string) {
+
+  // This is stupid, but we can't access the base m3u8 content if Firefox's Enhanced Tracking Protection is enabled. 
+  // This means that we can't read the available index-dvr.m3u8 URLs directly, we need to "guess" them by requesting
+  // other resources that share the same base URL. In this case, we are using the "storyboards" URL.
+
+  // Body of the gql query we will use to get the "storyboards" URL
+  const requestBody =
+  {
+    "operationName": "VideoPlayer_VODSeekbarPreviewVideo",
+    "variables": {
+      "includePrivate": false,
+      "videoID": videoId
+    },
+    "extensions": {
+      "persistedQuery": {
+        "version": 1,
+        "sha256Hash": "07e99e4d56c5a7c67117a154777b0baf85a5ffefa393b213f4bc712ccaf85dd6"
+      }
+    }
+  }
+
+  // Get api response
+  const response = await fetch("https://gql.twitch.tv/gql", {
+    "headers": {
+      "client-id": clientId,
+    },
+    "body": JSON.stringify(requestBody),
+    "method": "POST",
+    "mode": "cors",
+    "credentials": "omit"
+  })
+
+  if (!response.ok) {
+    throw new Error("Unable to fetch manifest")
+  }
+
+  const responseJson = await response.json()
+
+  // Extract storyboads URL from response
+  const fullStoryboardsUrl = responseJson["data"]["video"]["seekPreviewsURL"]
+
+  // Split the pathname of the url
+  const url = new URL(fullStoryboardsUrl);
+  const pathnamePieces = url.pathname.split("/");
+
+  // Check if the current url has the expected format (ends with /storyboards/<videoId>-info.json)
+  const expectedFile = `${videoId}-info.json`;
+  if (pathnamePieces.at(-1) !== expectedFile || pathnamePieces.at(-2) !== "storyboards") {
+    throw new Error(`Storyboards URL does not have the expected format: ${fullStoryboardsUrl}`);
+  }
+
+  // Take everything before "/storyboards"
+  const beforeStoryboards = pathnamePieces
+    .slice(0, pathnamePieces.indexOf("storyboards"))
+    .join("/");
+
+  // Rebuild full URL
+  url.pathname = beforeStoryboards
+  return url.toString();
 }


### PR DESCRIPTION
With our old implementation, vod m3u8 files from ongoing livestreams didn't have `#EXT-X-ENDLIST`. We are now fetching and modifying the m3u8 content to include the missing line before downloading it.

**Added quality selector for vods**
We are now displaying a popup with the available m3u8 files for the different resolutions. Only the selected quality will be downloaded and modified to include the missing line.